### PR TITLE
Fix syslog bug

### DIFF
--- a/ldap_access_log_humanizer/syslog_server.py
+++ b/ldap_access_log_humanizer/syslog_server.py
@@ -13,13 +13,14 @@ class SyslogUDPHandler(SocketServer.BaseRequestHandler):
         # openldap logs to local4 facility, which prepends a debug code of <167>
         data = data.lstrip('<167>')
         socket = self.request[1]
-        parser = Parser(data, self.server.args_dict)
-        parser.parse_line(str(data))
+        self.parser.parse_line(str(data))
+
 
 class UDPServer(SocketServer.UDPServer):
     def __init__(self, server_address, RequestHandlerClass, args_dict, bind_and_activate=True):
         SocketServer.UDPServer.__init__(self, server_address, RequestHandlerClass)
         self.args_dict = args_dict
+
 
 class SyslogServer():
 
@@ -30,6 +31,7 @@ class SyslogServer():
         if self.args_dict['port']:
             self.port = self.args_dict['port']
         self.logger = CustomLogger(self.args_dict)
+        self.parser = Parser(None, self.server.args_dict)
 
     def serve(self):
         server = UDPServer((self.host, int(self.port)), SyslogUDPHandler, self.args_dict)
@@ -49,7 +51,7 @@ class SyslogServer():
                     stderr=out,
                     umask=0o002,
                     pidfile=pidfile.TimeoutPIDLockFile(pidf),
-                    ) as context:
+            ) as context:
                 self.serve()
         else:
             # when running under systemd, we don't need daemonize, just start serving

--- a/ldap_access_log_humanizer/syslog_server.py
+++ b/ldap_access_log_humanizer/syslog_server.py
@@ -6,7 +6,10 @@ from ldap_access_log_humanizer.custom_logger import CustomLogger
 from ldap_access_log_humanizer.parser import Parser
 
 
-class SyslogUDPHandler(SocketServer.BaseRequestHandler):
+class CustomSyslogUDPHandler(SocketServer.BaseRequestHandler):
+    def __init__(self, parser):
+        SocketServer.BaseRequestHandler.__init__(self)
+        self.parser = parser
 
     def handle(self):
         data = bytes.decode(self.request[0].strip())
@@ -34,7 +37,7 @@ class SyslogServer():
         self.parser = Parser(None, self.server.args_dict)
 
     def serve(self):
-        server = UDPServer((self.host, int(self.port)), SyslogUDPHandler, self.args_dict)
+        server = UDPServer((self.host, int(self.port)), CustomSyslogUDPHandler(self.parser), self.args_dict)
         server.serve_forever(poll_interval=0.5)
 
     def start_syslog(self):

--- a/tests/unit-tests/test_syslog_server.py
+++ b/tests/unit-tests/test_syslog_server.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+from ldap_access_log_humanizer.syslog_server import SyslogUDPHandler
+from ldap_access_log_humanizer.syslog_server import UDPServer
+from ldap_access_log_humanizer.syslog_server import SyslogServer
+from ldap_access_log_humanizer.parser import Parser
+
+
+class TestSyslogServer():
+    # Note: this doesn't actually test the class directly, it just tests the logic within the class to verify functionality is as expected
+    def test_handle(self):
+        args_dict = {'output_mozdef': False, 'output_stdout': True, 'input_type': 'file', 'output_file': False, 'output_syslog': False,
+                     'host': '0.0.0.0', 'daemonize': False, 'input_file_name': None, 'mozdef_url': 'https://127.0.0.1:8443/events',
+                     'noconfig': False, 'output_file_name': 'humanizer.log', 'output_stderr': False, 'config': 'humanizer_settings.json',
+                     'port': '1514', 'syslog_facility': 'LOG_LOCAL5', 'verbose': True}
+
+        log_lines = [
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 fd=28 ACCEPT from IP=127.0.0.1:44182 (IP=0.0.0.0:389)',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 op=0 EXT oid=1.3.6.1.4.1.1466.20037',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 op=0 STARTTLS',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 op=0 RESULT oid= err=0 text=',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 fd=28 TLS established tls_ssf=256 ssf=256',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 op=1 BIND dn="uid=nagioscheck,ou=logins,dc=mozilla" method=128',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 op=1 BIND dn="uid=nagioscheck,ou=logins,dc=mozilla" mech=SIMPLE ssf=0',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 op=1 RESULT tag=97 err=0 text=',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 op=2 SRCH base="dc=mozilla" scope=0 deref=0 filter="(objectClass=*)"',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 op=2 SEARCH RESULT tag=101 err=0 nentries=1 text=',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 op=3 UNBIND',
+            '<167>Jul  2 19:40:26 slave1.ldap.mdc1.mozilla.com slapd[5436]: conn=1150013 fd=28 closed'
+        ]
+
+        parser = Parser(None, args_dict)
+        assert len(parser.connections) == 0
+
+        for log in log_lines:
+            new_log = log.lstrip('<167>')
+            assert new_log.startswith('<167>') == False
+            parser.parse_line(new_log)
+            assert isinstance(parser.connections, dict)
+            # All of our test data is from a single connection (so it will only ever be 1, until the close)
+            if new_log.endswith('closed'):
+                assert len(parser.connections) == 0
+            else:
+                assert len(parser.connections) == 1
+
+        # This is zeroed out after because the connection is gone at this point
+        assert len(parser.connections) == 0

--- a/tests/unit-tests/test_syslog_server.py
+++ b/tests/unit-tests/test_syslog_server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from ldap_access_log_humanizer.syslog_server import SyslogUDPHandler
+from ldap_access_log_humanizer.syslog_server import CustomSyslogUDPHandler
 from ldap_access_log_humanizer.syslog_server import UDPServer
 from ldap_access_log_humanizer.syslog_server import SyslogServer
 from ldap_access_log_humanizer.parser import Parser


### PR DESCRIPTION
This attempts to do two things:

1. Move Parser instantiation into the parent class, so it's not consistently overwritten.  If it turns out this doesn't work, we could go ugly and use a global or find another way keep state
2. Describe in unit-tests the type of problem we're trying to work around