### PR TITLE
Avoid stack track on unknown LDAP error codes

### DIFF
--- a/ldap_access_log_humanizer/operation.py
+++ b/ldap_access_log_humanizer/operation.py
@@ -112,7 +112,7 @@ class Operation:
 
         # If there was an error, add text error value (so humans can understand)
         if match:
-            self.error = LDAP_ERROR_CODES[int(match.group(1))]
+            self.error = LDAP_ERROR_CODES.get(int(match.group(1)))
 
     def add_event(self, rest):
         verbs = [

--- a/ldap_access_log_humanizer/operation.py
+++ b/ldap_access_log_humanizer/operation.py
@@ -3,6 +3,8 @@ import re
 LDAP_ERROR_CODES = {
     # Indicates the requested client operation completed successfully.
     0: "LDAP_SUCCESS",
+    # Indicates that the associated request was out of sequence with another operation in progress (e.g., a non-bind request in the middle of a multi-stage SASL bind).It does not indicate that the client has sent an erroneous message.
+    1: "LDAP_OPERATIONS_ERROR",
     # Indicates that the server has received an invalid or malformed request from the client.
     2: "LDAP_PROTOCOL_ERROR",
     # Indicates that the operation's time limit specified by either the client or the server has been exceeded. On search operations, incomplete results are returned.

--- a/ldap_access_log_humanizer/operation.py
+++ b/ldap_access_log_humanizer/operation.py
@@ -114,7 +114,7 @@ class Operation:
 
         # If there was an error, add text error value (so humans can understand)
         if match:
-            self.error = LDAP_ERROR_CODES.get(int(match.group(1)))
+            self.error = LDAP_ERROR_CODES.get(int(match.group(1)), "UNKNOWN")
 
     def add_event(self, rest):
         verbs = [

--- a/tests/unit-tests/test_operation.py
+++ b/tests/unit-tests/test_operation.py
@@ -83,3 +83,26 @@ class TestOperation():
         assert operation.response_verb_details == set(
             ['tag=101', 'err=0', 'nentries=1', 'text='])
         assert operation.loggable() == True
+        assert operation.error == "LDAP_SUCCESS"
+
+    def test_add_bind_multiple_with_result_and_unknown_error(self):
+        rest = 'BIND dn="uid=bind-generateusers,ou=logins,dc=example" method=128'
+        rest2 = 'BIND dn="uid=bind-generateusers,ou=logins,dc=example" mech=SIMPLE ssf=0'
+        rest3 = 'RESULT tag=97 err=300 text='
+
+        operation = Operation(0)
+        operation.add_event(rest)
+        operation.add_event(rest2)
+        operation.add_event(rest3)
+
+        assert isinstance(operation, Operation)
+        assert operation.op_id == 0
+        assert operation.requests == [
+            {'verb': 'BIND',
+             'details': ['dn="uid=bind-generateusers,ou=logins,dc=example"', 'mech=SIMPLE', 'method=128', 'ssf=0'],
+             }]
+        assert operation.response_verb == "RESULT"
+        assert operation.response_verb_details == set(
+            ['tag=97', 'err=300', 'text='])
+        assert operation.loggable() == True
+        assert operation.error == "UNKNOWN"


### PR DESCRIPTION
Addresses these stack traces...

Sep  9 08:16:40 ldapproxy2.dmz.mdc2.mozilla.com humanizer.py[919]: File "/usr/lib/python2.7/site-packages/ldap_access_log_humanizer/operation.py", line 115, in add_error
Sep  9 08:16:40 ldapproxy2.dmz.mdc2.mozilla.com humanizer.py[919]: self.error = LDAP_ERROR_CODES[int(match.group(1))]
Sep  9 08:16:40 ldapproxy2.dmz.mdc2.mozilla.com humanizer.py[919]: KeyError: 1

I'm also trying to get the logs to find out what error code we're missing here.