### PR TITLE
RPM improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ pylint:
 	@find ./* `git submodule --quiet foreach 'echo -n "-path ./$$path -prune -o "'` -type f -name '*.py' -exec pylint -r no --disable=locally-disabled --rcfile=/dev/null {} \;
 
 rpm:
-	fpm -s python -t rpm --after-install restart.sh --after-upgrade restart.sh --rpm-dist "$$(rpmbuild -E '%{?dist}' | sed -e 's#^\.##')" --iteration 1 setup.py
+	fpm -s python -t rpm --after-install restart.sh --after-upgrade restart.sh --rpm-dist "$$(rpmbuild -E '%{?dist}' | sed -e 's#^\.##')" --iteration 2 setup.py
 	@rm -rf build $(PACKAGE).egg-info
 
 clean:

--- a/restart.sh
+++ b/restart.sh
@@ -1,2 +1,3 @@
 /usr/bin/chmod 644 /usr/lib/systemd/system/humanizer.service
+/usr/bin/systemctl daemon-reload
 /usr/bin/systemctl restart humanizer.service

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,51 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+''' Packaging setup '''
 
-config = {
-    'description': '',
-    'author': '',
-    'url': '',
-    'download_url': '',
-    'author_email': 'jdow@mozilla, jclaudius@mozilla.com',
-    'version': "0.0.3",
-    'install_requires': ['requests'],
-    'packages': ['ldap_access_log_humanizer'],
-    'scripts': ['humanizer.py'],
-    'data_files': [('/etc/humanizer', ['humanizer_settings.json.default']),
+import os
+import subprocess
+from setuptools import setup
+
+NAME = 'ldap-access-log-humanizer'
+VERSION = '0.0.3'
+
+def git_version():
+    ''' Return the git revision as a string '''
+    def _minimal_ext_cmd(cmd):
+        # construct minimal environment
+        env = {}
+        for envvar in ['SYSTEMROOT', 'PATH']:
+            val = os.environ.get(envvar)
+            if val is not None:
+                env[envvar] = val
+        # LANGUAGE is used on win32
+        env['LANGUAGE'] = 'C'
+        env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
+        out = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                               env=env).communicate()[0]
+        return out
+
+    try:
+        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
+        git_revision = out.strip().decode('ascii')
+    except OSError:
+        git_revision = u"Unknown"
+
+    return git_revision
+
+setup(
+    name=NAME,
+    packages=[NAME.replace('-','_')],
+    version=VERSION,
+    author='',
+    author_email='secops@mozilla.com',
+    description=('Make OpenLDAP access logs more readable for humans and machines\n' +
+                 'This package is built upon commit ' + git_version()),
+    license='MPL',
+    url='https://github.com/mozilla/ldap-access-log-humanizer',
+    install_requires=['requests'],
+    scripts=['humanizer.py'],
+    data_files=[('/etc/humanizer', ['humanizer_settings.json.default']),
         ('/usr/lib/systemd/system', ['humanizer.service']),
         ('/etc/logrotate.d/', ['humanizer-logrotate']),
         ('/etc/rsyslog.d/', ['humanizer-rsyslog.conf'])],
-    'name': 'ldap-access-log-humanizer'
-}
-
-setup(**config)
+)


### PR DESCRIPTION
A small set of changes around RPM packaging - add a systemctl daemon-reload (which is a miss in the previous versions), improve setup.py to report more useful info to the sysadmin users, and bump the iteration so we can deploy these as a package.